### PR TITLE
Mark PowerShellStandard.Library Assets as Private to Prevent Inclusion in Publishing

### DIFF
--- a/src/dotnetTemplate/Microsoft.PowerShell.Standard.Module.Template/Microsoft.PowerShell.Standard.Module.Template/Microsoft.PowerShell.Standard.Module.Template.csproj
+++ b/src/dotnetTemplate/Microsoft.PowerShell.Standard.Module.Template/Microsoft.PowerShell.Standard.Module.Template/Microsoft.PowerShell.Standard.Module.Template.csproj
@@ -6,7 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="PowerShellStandard.Library" Version="5.1.0-preview-03" />
+    <PackageReference Include="PowerShellStandard.Library" Version="5.1.0-preview-03">
+      <PrivateAssets>All</PrivateAssets>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
The reference assemblies in PowerShell standard are intended for development and not intended for inclusion in publish modules. Marking the assets as privates allows for proper development against the reference assemblies but will exclude the package assets from being published or packaged.