### PR TITLE
Changes to build template as part of ./build.ps1 -pack

### DIFF
--- a/PowerShellStandard.psm1
+++ b/PowerShellStandard.psm1
@@ -76,5 +76,20 @@ function Export-NuGetPackage
             Pop-Location
         }
     }
+    # Create the template nupkg
+    try {
+        $templateDir = Join-Path $PsScriptRoot src/dotnetTemplate
+        Push-Location $templateDir
+        $result = dotnet pack
+        if ( $? ) {
+            Copy-Item (Join-Path $templateDir "bin/Debug/*.nupkg") $PsScriptRoot
+        }
+        else {
+            Write-Error -Message $result
+        }
+    }
+    finally {
+        Pop-Location
+    }
 
 }

--- a/src/dotnetTemplate/Microsoft.PowerShell.Standard.Module.Template.csproj
+++ b/src/dotnetTemplate/Microsoft.PowerShell.Standard.Module.Template.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFramework>netstandard2.0</TargetFramework>
+        <NuspecFile>./Microsoft.PowerShell.Standard.Module.Template/Microsoft.PowerShell.Standard.Module.Template.nuspec</NuspecFile>
+        <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    </PropertyGroup>
+</Project>

--- a/src/dotnetTemplate/Microsoft.PowerShell.Standard.Module.Template/Microsoft.PowerShell.Standard.Module.Template.nuspec
+++ b/src/dotnetTemplate/Microsoft.PowerShell.Standard.Module.Template/Microsoft.PowerShell.Standard.Module.Template.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>Microsoft.PowerShell.Standard.Module.Template</id>
-    <version>0.1.0</version>
+    <version>0.1.1</version>
     <title>PowerShell Standard module</title>
     <authors>Microsoft</authors>
     <owners>Microsoft,PowerShellTeam</owners>

--- a/src/dotnetTemplate/Microsoft.PowerShell.Standard.Module.Template/Microsoft.PowerShell.Standard.Module.Template/Microsoft.PowerShell.Standard.Module.Template.csproj
+++ b/src/dotnetTemplate/Microsoft.PowerShell.Standard.Module.Template/Microsoft.PowerShell.Standard.Module.Template/Microsoft.PowerShell.Standard.Module.Template.csproj
@@ -8,6 +8,7 @@
   <ItemGroup>
     <PackageReference Include="PowerShellStandard.Library" Version="5.1.0-preview-03">
       <PrivateAssets>All</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Additional fix in the template .csproj file to fix missing close `<PackageReference>`
