### PR TITLE
be more clear about hosts in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ Windows PowerShell includes an interactive prompt and a scripting environment th
 
 The PowerShell Standard has been created to assist developers create modules and PowerShell hosts which will run on PowerShell and which will use only APIs that exist across different versions of PowerShell.
 
+> NOTE: You should not use PowerShell Standard for standalone applications that leverage PowerShell.
+For that, you should use the [PowerShell SDK](https://www.nuget.org/packages/Microsoft.PowerShell.SDK).
+PowerShell Standard's main scenario is for running within a PowerShell session.
+
 ## PowerShell Standard Libraries
 
 Two PowerShell Standard `.nupkg` versions are available:

--- a/README.md
+++ b/README.md
@@ -8,17 +8,17 @@ It includes a command-line shell, an associated scripting language and a framewo
 Windows PowerShell is a Windows command-line shell designed especially for system administrators.
 Windows PowerShell includes an interactive prompt and a scripting environment that can be used independently or in combination.
 
-The PowerShell Standard has been created to assist developers create modules and PowerShell hosts which will use only APIs that exist across different versions of PowerShell.
+The PowerShell Standard has been created to assist developers create modules and PowerShell hosts which will run on PowerShell and which will use only APIs that exist across different versions of PowerShell.
 
 ## PowerShell Standard Libraries
 
 Two PowerShell Standard `.nupkg` versions are available:
 
 - PowerShell Standard.Library Version 3
-  - This allows you to create PowerShell modules and host which will run on PowerShell Version 3 and later including PowerShellCore
+  - This allows you to create PowerShell modules and PowerShell hosts which will run on PowerShell Version 3 and later including PowerShellCore
 
 - PowerShell Standard.Library Version 5.1
-  - This allows you to create PowerShell modules and host which will run on PowerShell Version 5.1 and later including PowerShellCore
+  - This allows you to create PowerShell modules and PowerShell hosts which will run on PowerShell Version 5.1 and later including PowerShellCore
 
 Both are available on [NuGet.org](https://www.nuget.org/packages/PowerShellStandard.Library)
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ It includes a command-line shell, an associated scripting language and a framewo
 Windows PowerShell is a Windows command-line shell designed especially for system administrators.
 Windows PowerShell includes an interactive prompt and a scripting environment that can be used independently or in combination.
 
-The PowerShell Standard has been created to assist developers create modules and PowerShell hosts which will run on PowerShell and which will use only APIs that exist across different versions of PowerShell.
+PowerShell Standard is a reference assembly that has been created to assist developers create modules and PowerShell hosts which will run on PowerShell.
+The reference assembly contains no actual implementation but rather will allow you to use only APIs that exist across different versions of PowerShell. This means that you still need to run within a PowerShell runtime.
 
 > NOTE: You should not use PowerShell Standard for standalone applications that leverage PowerShell.
 For that, you should use the [PowerShell SDK](https://www.nuget.org/packages/Microsoft.PowerShell.SDK).


### PR DESCRIPTION
Fixes #63 where a user was confused into thinking PowerShellStandard can be used for hosting PowerShell in a standalone app. This is not true and the user should use PowerShell SDK