### PR TITLE
WIP: Update template to use PSL 5.1.0

### DIFF
--- a/src/5/PowerShellStandard.Library.nuspec
+++ b/src/5/PowerShellStandard.Library.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>PowerShellStandard.Library</id>
-    <version>5.1.1</version>
+    <version>5.1.0</version>
     <title>PowerShellStandard.Library</title>
     <authors>Microsoft</authors>
     <owners>Microsoft,PowerShellTeam</owners>

--- a/src/5/System.Management.Automation-lib.csproj
+++ b/src/5/System.Management.Automation-lib.csproj
@@ -5,7 +5,7 @@
     <AssemblyOriginatorKeyFile>..\signing\visualstudiopublic.snk</AssemblyOriginatorKeyFile>
     <AssemblyName>System.Management.Automation</AssemblyName>
     <AssemblyVersion>3.0.0</AssemblyVersion>
-    <FileVersion>5.1.1</FileVersion>
+    <FileVersion>5.1.0</FileVersion>
     <DelaySign>True</DelaySign>
     <DefineConstants>RUNTIME_SERIALIZATION</DefineConstants>
     <NuspecFile>./PowershellStandard.Library.nuspec</NuspecFile>

--- a/src/dotnetTemplate/Microsoft.PowerShell.Standard.Module.Template/Microsoft.PowerShell.Standard.Module.Template.nuspec
+++ b/src/dotnetTemplate/Microsoft.PowerShell.Standard.Module.Template/Microsoft.PowerShell.Standard.Module.Template.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>Microsoft.PowerShell.Standard.Module.Template</id>
-    <version>0.1.4</version>
+    <version>0.1.5</version>
     <title>PowerShell Standard module</title>
     <authors>Microsoft</authors>
     <owners>Microsoft,PowerShellTeam</owners>

--- a/src/dotnetTemplate/Microsoft.PowerShell.Standard.Module.Template/Microsoft.PowerShell.Standard.Module.Template/.template.config/template.json
+++ b/src/dotnetTemplate/Microsoft.PowerShell.Standard.Module.Template/Microsoft.PowerShell.Standard.Module.Template/.template.config/template.json
@@ -16,10 +16,10 @@
     "PowerShellStandardVersion":{
       "type": "parameter",
       "datatype":"choice",
-      "defaultValue": "5.1.0-preview-06",
+      "defaultValue": "5.1.0",
       "choices": [
         {
-          "choice": "5.1.0-preview-06",
+          "choice": "5.1.0",
           "description": "PowerShell Standard 5.1"
         },
         {
@@ -27,7 +27,7 @@
           "description": "PowerShell Standard 3.0"
         }
       ],
-      "replaces": "5.1.0-preview-06"
+      "replaces": "5.1.0"
     },
     "skipRestore": {
       "type": "parameter",

--- a/src/dotnetTemplate/Microsoft.PowerShell.Standard.Module.Template/Microsoft.PowerShell.Standard.Module.Template/Microsoft.PowerShell.Standard.Module.Template.csproj
+++ b/src/dotnetTemplate/Microsoft.PowerShell.Standard.Module.Template/Microsoft.PowerShell.Standard.Module.Template/Microsoft.PowerShell.Standard.Module.Template.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="PowerShellStandard.Library" Version="5.1.1">
+    <PackageReference Include="PowerShellStandard.Library" Version="5.1.0">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
 

--- a/src/dotnetTemplate/Microsoft.PowerShell.Standard.Module.Template/Microsoft.PowerShell.Standard.Module.Template/Microsoft.PowerShell.Standard.Module.Template.psd1
+++ b/src/dotnetTemplate/Microsoft.PowerShell.Standard.Module.Template/Microsoft.PowerShell.Standard.Module.Template/Microsoft.PowerShell.Standard.Module.Template.psd1
@@ -23,7 +23,7 @@ Author = 'Unknown'
 CompanyName = 'Unknown'
 
 # Copyright statement for this module
-Copyright = '(c) 2018 Unknown. All rights reserved.'
+Copyright = '(c) 2019 Unknown. All rights reserved.'
 
 # Description of the functionality provided by this module
 # Description = ''

--- a/src/dotnetTemplate/README.md
+++ b/src/dotnetTemplate/README.md
@@ -95,9 +95,9 @@ PowerShell Standard Module (C#)
 Author: Microsoft Corporation
 Options:
   -v|--powershell-standard-version
-                                        5.1.1               - PowerShell Standard 5.1.1
+                                        5.1.0               - PowerShell Standard 5.1.0
                                         3.0.0-preview-02    - PowerShell Standard 3.0
-                                    Default: 5.1.1
+                                    Default: 5.1.0
 
   --no-restore                      If specified, skips the automatic restore of the project on create.
                                     bool - Optional

--- a/src/dotnetTemplate/README.md
+++ b/src/dotnetTemplate/README.md
@@ -2,7 +2,7 @@
 
 A `dotnet new` template that creates an example PowerShell C# module that uses PowerShellStandard.
 
-```
+```powershell
 dotnet new psmodule
 ```
 
@@ -12,7 +12,7 @@ To use the template, you must first install it so that it is recognized in `dotn
 
 ### From nuget.org
 
-```
+```powershell
 dotnet new -i Microsoft.PowerShell.Standard.Module.Template
 ```
 
@@ -33,7 +33,7 @@ Now checkout the [usage](#usage).
 
 Once the template is installed, you will see it in your template list:
 
-```
+```text
 PS> dotnet new -l
 
 Usage: new [options]
@@ -75,7 +75,7 @@ MVC ViewStart                                     viewstart                     
 
 To get more details, add the `-h` flag:
 
-```
+```text
 PS > dotnet new psmodule -h
 Usage: new [options]
 
@@ -106,7 +106,7 @@ Options:
 
 To create a template using the defaults:
 
-```
+```text
 > dotnet new psmodule
 The template "PowerShell Standard Module" was created successfully.
 
@@ -124,7 +124,7 @@ Notice that it restores automatically.
 
 You can optionally specify PowerShell Standard V3 by running:
 
-```
+```text
 dotnet new psmodule --powershell-standard-version 3.0.0-preview-02
 ```
 

--- a/tools/releaseBuild/signing.xml
+++ b/tools/releaseBuild/signing.xml
@@ -6,7 +6,7 @@
          dest="__OUTPATHROOT__\release\out\Microsoft.PowerShell.Standard.Module.Template.0.1.4.nupkg" />
     <file  src="__INPATHROOT__\release\out\PowerShellStandard.Library.3.0.0-preview-02.nupkg" signType="CP-401405"
          dest="__OUTPATHROOT__\release\out\PowerShellStandard.Library.3.0.0-preview-02.nupkg" />
-    <file  src="__INPATHROOT__\release\out\PowerShellStandard.Library.5.1.1.nupkg" signType="CP-401405"
-         dest="__OUTPATHROOT__\release\out\PowerShellStandard.Library.5.1.1.nupkg" />
+    <file  src="__INPATHROOT__\release\out\PowerShellStandard.Library.5.1.0.nupkg" signType="CP-401405"
+         dest="__OUTPATHROOT__\release\out\PowerShellStandard.Library.5.1.0.nupkg" />
  </job>
 </SignConfigXML>


### PR DESCRIPTION
There are a few things that need to be worked out here.  There was a PR merged by @JamesWTruher back in March that updated parts of the template for use of `PSL 5.1.1`.  But I don't see a 5.1.1 version on nuget.org.  The latest [there](https://www.nuget.org/packages/PowerShellStandard.Library/) is `5.1.0`.

Also, I installed the template today and the project it scaffolded for me was still using `5.1.0-preview-06`.  So I think we need an update to move to `5.1.0` or perhaps `5.1.1` when it gets published to nuget.org.

I updated the generated module manifest copyright to 2019 and added code-block language specifiers in the README.md file to eliminate the markdownlint warnings I was getting.