### PR TITLE
Add copyright header to `.cs`, `.ps1` and `psm1` files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,3 +3,6 @@ root = true
 [*]
 charset = utf-8
 insert_final_newline = true
+
+[*.{cs,ps1,psm1}]
+file_header_template = Copyright (c) Microsoft Corporation.\nLicensed under the MIT License.

--- a/PowerShellStandard.psm1
+++ b/PowerShellStandard.psm1
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 function Start-Build {
     param ( [switch]$CoreOnly )
     # $versions = 3,5

--- a/build.ps1
+++ b/build.ps1
@@ -1,4 +1,7 @@
 #!/usr/bin/env pwsh
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 param ( 
     [Parameter(HelpMessage="Remove earlier built versions")][switch]$Clean,
     [Parameter(HelpMessage="Run the tests")][switch]$Test,

--- a/doc/assets/export-TypeDoc.ps1
+++ b/doc/assets/export-TypeDoc.ps1
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 $tlist = Import-CSV TypeComparison.csv
 @'
 # PowerShell Standard Library 5

--- a/doc/assets/export-typecompare.ps1
+++ b/doc/assets/export-typecompare.ps1
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 class CommonType {
     [string]$Fullname
     [bool]$PowerShell51

--- a/src/3/System.Management.Automation-lib.cs
+++ b/src/3/System.Management.Automation-lib.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 /*
 
 First cut at removing apis that we might want to deprecate or not support

--- a/src/5/System.Management.Automation-lib.cs
+++ b/src/5/System.Management.Automation-lib.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 namespace Microsoft.PowerShell {
   public sealed class DeserializingTypeConverter : System.Management.Automation.PSTypeConverter {

--- a/src/dotnetTemplate/Microsoft.PowerShell.Standard.Module.Template/Microsoft.PowerShell.Standard.Module.Template/TestSampleCmdletCommand.cs
+++ b/src/dotnetTemplate/Microsoft.PowerShell.Standard.Module.Template/Microsoft.PowerShell.Standard.Module.Template/TestSampleCmdletCommand.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System;
 using System.Management.Automation;
 using System.Management.Automation.Runspaces;

--- a/test/3/core/Class1.cs
+++ b/test/3/core/Class1.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System;
 using System.Management.Automation;
 

--- a/test/3/core/PSS3.Tests.ps1
+++ b/test/3/core/PSS3.Tests.ps1
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 Describe "PowerShell Standard 3" {
     BeforeAll {
         $cmdletAssembly = "bin/Release/netstandard2.0/Demo.Cmdlet.dll" 

--- a/test/3/full/Class1.cs
+++ b/test/3/full/Class1.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System;
 using System.Management.Automation;
 

--- a/test/3/full/PSS3.Tests.ps1
+++ b/test/3/full/PSS3.Tests.ps1
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 Describe "PowerShell Standard 3" {
     BeforeAll {
         $cmdletAssembly = "bin/Release/net452/Demo.Cmdlet.dll" 

--- a/test/5/core/Class1.cs
+++ b/test/5/core/Class1.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System;
 using System.Management.Automation;
 using System.Management.Automation.Runspaces;

--- a/test/5/core/PSS5.Tests.ps1
+++ b/test/5/core/PSS5.Tests.ps1
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 Describe 'PowerShell Standard 5' {
 
     BeforeAll {

--- a/test/5/full/Class1.cs
+++ b/test/5/full/Class1.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System;
 using System.Management.Automation;
 using System.Management.Automation.Runspaces;

--- a/test/5/full/PSS5.Tests.ps1
+++ b/test/5/full/PSS5.Tests.ps1
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 Describe 'PowerShell Standard 5 - Full CLR' {
 
     BeforeAll {

--- a/test/Build.Tests.ps1
+++ b/test/Build.Tests.ps1
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 Describe "Ensure that the created file versions match what is in the Signing.xml file" {
     BeforeAll {
         $baseDir = Resolve-Path (Join-Path $PsScriptRoot "..")

--- a/test/dotnetTemplate/dotnetTemplate.Tests.ps1
+++ b/test/dotnetTemplate/dotnetTemplate.Tests.ps1
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 Describe "PowerShell Standard C# Module Template" {
     Context "Targeting PowerShell Standard 5.1" {
         BeforeAll {

--- a/tools/releaseBuild/Image/buildStandard.ps1
+++ b/tools/releaseBuild/Image/buildStandard.ps1
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 param ( [string]$target )
 if ( ! (test-path ${target} ) ) {
     new-item -type directory ${target}

--- a/tools/releaseBuild/Image/dockerInstall.psm1
+++ b/tools/releaseBuild/Image/dockerInstall.psm1
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 function Install-ChocolateyPackage
 {
     param(

--- a/tools/releaseBuild/vstsbuild.ps1
+++ b/tools/releaseBuild/vstsbuild.ps1
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 [cmdletbinding()]
 param()
 


### PR DESCRIPTION
* Add copyright header to `.cs`, `.ps1` and `psm1` files.
* Add copyright header template to EditorConfig.